### PR TITLE
feat: add Groq tool calling for RAG and improve PDF text extraction

### DIFF
--- a/src/services/localLLMService.ts
+++ b/src/services/localLLMService.ts
@@ -39,13 +39,75 @@ import { ragService } from './ragService';
 
 import log from '../utils/logger';
 
+interface GroqToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+interface GroqResponseMessage {
+  content?: string | null;
+  tool_calls?: GroqToolCall[];
+  role?: string;
+}
+
 interface GroqResponse {
   choices?: Array<{
-    message?: {
-      content?: string;
-    };
+    message?: GroqResponseMessage;
+    finish_reason?: string;
   }>;
 }
+
+// ─── RAG Tool Definitions for Groq Tool Calling ────────────────
+const RAG_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'search_knowledge_base',
+      description:
+        'Search the business knowledge base for relevant information to answer the caller\'s question. Use this when the caller asks about products, services, policies, pricing, hours, procedures, or any business-specific information.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'The search query — rephrase the caller\'s question to maximize relevance. Be specific.',
+          },
+          max_results: {
+            type: 'number',
+            description: 'Max results to return (1-5). Use 3 for normal queries, 5 for complex ones.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_document_details',
+      description:
+        'Get detailed information from a specific uploaded document by searching for a keyword or topic within it. Use when you need precise details from a known document.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Keyword or topic to search for within documents.',
+          },
+          document_name: {
+            type: 'string',
+            description: 'Optional: specific document name to search within.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+];
 
 
 
@@ -557,54 +619,180 @@ class GroqLLMService {
       { hasPhone, hasEmail } // Pass contact info status
     );
 
-    let ragContext = '';
-    if (knowledgeBase.id) {
-      log.debug(`🔍 Fetching RAG context for KB ID ${knowledgeBase.id}...`);
-      const contextDocs = await ragService.searchRelevantContext(userMessage, knowledgeBase.id, 3);
-      if (contextDocs && contextDocs.length > 0) {
-        ragContext = `\n\n=== RELEVANT KNOWLEDGE BASE CONTEXT ===\n${contextDocs.join('\n\n')}\n=======================================\nUse the above information to help answer the user.`;
-      }
-    }
-
     // 2. Conversation History (last 8 messages for better context)
     const recentHistory = conversationHistory.slice(-8);
 
+    const hasKnowledgeBase = !!knowledgeBase.id;
+
     // Build messages array for Groq API (OpenAI format)
-    const groqMessages = [
-      { role: 'system' as const, content: systemPrompt + ragContext },
+    const groqMessages: Array<{ role: 'system' | 'user' | 'assistant' | 'tool'; content: string; tool_call_id?: string; name?: string; tool_calls?: GroqToolCall[] }> = [
+      { role: 'system' as const, content: systemPrompt + (hasKnowledgeBase ? '\n\nYou have access to a knowledge base. Use the search_knowledge_base tool when the caller asks about business-specific information. ALWAYS search before answering questions about products, services, policies, pricing, or procedures.' : '') },
       ...recentHistory.map(msg => ({
-        role: msg.speaker === 'agent' ? 'assistant' as const : 'user' as const,
+        role: (msg.speaker === 'agent' ? 'assistant' : 'user') as 'assistant' | 'user',
         content: msg.speaker === 'agent' ? this.cleanFinalAnswer(msg.text) : msg.text
       })),
       { role: 'user' as const, content: `${userMessage}\n\nRespond naturally to the caller, then AFTER your response, add a JSON block with extracted information.\n\nFormat:\n[Your response]\n\n\`\`\`json\n{"extracted": {"name": "caller name or null", "email": "email or null", "phone": "phone or null", "company": "company or null"}, "priority": "low|medium|high|critical", "category": "inquiry|support|complaint|appointment|other"}\n\`\`\`` }
     ];
 
-    // Helper function for Groq API request
+    // ─── Tool-calling RAG handler ──────────────────────────────────
+    // Executes a tool call by dispatching to the right handler
+    const executeToolCall = async (toolCall: GroqToolCall): Promise<string> => {
+      const { name, arguments: argsStr } = toolCall.function;
+      let args: Record<string, unknown>;
+      try {
+        args = JSON.parse(argsStr);
+      } catch {
+        return JSON.stringify({ error: 'Invalid tool arguments' });
+      }
+
+      if (name === 'search_knowledge_base' && knowledgeBase.id) {
+        const query = String(args.query || userMessage);
+        const maxResults = Math.min(Number(args.max_results) || 3, 5);
+        log.debug(`🔧 Tool call: search_knowledge_base("${query}", limit=${maxResults})`);
+
+        try {
+          const docs = await ragService.searchRelevantContext(query, knowledgeBase.id, maxResults);
+          if (docs && docs.length > 0) {
+            log.debug(`✅ KB search returned ${docs.length} results`);
+            return JSON.stringify({
+              results: docs.map((content, i) => ({ rank: i + 1, content })),
+              total: docs.length,
+            });
+          }
+          return JSON.stringify({ results: [], total: 0, note: 'No matching documents found.' });
+        } catch (err) {
+          log.warn('⚠️ KB search failed:', err);
+          return JSON.stringify({ error: 'Knowledge base search failed', details: err instanceof Error ? err.message : 'Unknown error' });
+        }
+      }
+
+      if (name === 'get_document_details' && knowledgeBase.id) {
+        const query = String(args.query || '');
+        log.debug(`🔧 Tool call: get_document_details("${query}")`);
+
+        try {
+          const docs = await ragService.searchRelevantContext(query, knowledgeBase.id, 5);
+          if (docs && docs.length > 0) {
+            return JSON.stringify({
+              results: docs.map((content, i) => ({ rank: i + 1, content, source: args.document_name || 'knowledge base' })),
+              total: docs.length,
+            });
+          }
+          return JSON.stringify({ results: [], total: 0 });
+        } catch (err) {
+          return JSON.stringify({ error: 'Document search failed' });
+        }
+      }
+
+      return JSON.stringify({ error: `Unknown tool: ${name}` });
+    };
+
+    // ─── Groq API request with tool-calling loop ─────────────────
     const makeGroqRequest = async (): Promise<string | null> => {
       if (!this.groqAvailable) return null;
 
       const settings = getCurrentGroqSettings();
-      try {
-        log.debug(`🚀 Calling Groq API via proxy (model: ${settings.model}, temp: ${settings.temperature})...`);
+      const MAX_TOOL_ROUNDS = 3; // Prevent infinite loops
 
-        const data = await proxyJSON<GroqResponse>(ProxyRoutes.COMPLETIONS, {
-          model: settings.model,
-          messages: groqMessages,
-          temperature: settings.temperature,
-          max_tokens: settings.maxTokens,
-          top_p: settings.topP,
-        }, { timeout: REQUEST_TIMEOUT });
+      // Working copy of messages for multi-turn tool calling
+      const messages = [...groqMessages];
 
-        const content = data.choices?.[0]?.message?.content;
-        if (content) {
-          log.debug('✅ Groq response received via proxy');
-          return content;
+      for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
+        try {
+          const requestPayload: Record<string, unknown> = {
+            model: settings.model,
+            messages,
+            temperature: settings.temperature,
+            max_tokens: settings.maxTokens,
+            top_p: settings.topP,
+          };
+
+          // Only include tools on the first round or if previous round had tool calls
+          // and only if knowledge base is configured
+          if (hasKnowledgeBase && round <= MAX_TOOL_ROUNDS - 1) {
+            requestPayload.tools = RAG_TOOLS;
+            requestPayload.tool_choice = round === 0 ? 'auto' : 'auto';
+          }
+
+          log.debug(`🚀 Groq API call (round ${round + 1}, model: ${settings.model})...`);
+
+          const data = await proxyJSON<GroqResponse>(ProxyRoutes.COMPLETIONS, requestPayload, { timeout: REQUEST_TIMEOUT });
+
+          const choice = data.choices?.[0];
+          if (!choice?.message) return null;
+
+          const { content, tool_calls } = choice.message;
+
+          // If model returned tool calls, execute them and loop
+          if (tool_calls && tool_calls.length > 0 && round < MAX_TOOL_ROUNDS) {
+            log.debug(`🔧 Model requested ${tool_calls.length} tool call(s) in round ${round + 1}`);
+
+            // Add the assistant message with tool_calls to history
+            messages.push({
+              role: 'assistant' as const,
+              content: content || '',
+              tool_calls,
+            });
+
+            // Execute each tool call and add results
+            for (const tc of tool_calls) {
+              const result = await executeToolCall(tc);
+              messages.push({
+                role: 'tool' as const,
+                tool_call_id: tc.id,
+                name: tc.function.name,
+                content: result,
+              });
+            }
+
+            // Continue loop — model will see tool results and generate final answer
+            continue;
+          }
+
+          // Final answer (no more tool calls)
+          if (content) {
+            log.debug(`✅ Groq response received (${round > 0 ? `after ${round} tool round(s)` : 'direct'})`);
+            return content;
+          }
+
+          return null;
+        } catch (error) {
+          log.warn(`⚠️ Groq request failed (round ${round + 1}):`, error instanceof Error ? error.message : error);
+
+          // If tool calling failed, retry without tools as fallback
+          if (hasKnowledgeBase && round === 0) {
+            log.debug('🔄 Retrying without tools (fallback to context injection)...');
+            // Fallback: do a direct RAG search and inject context
+            try {
+              const docs = await ragService.searchRelevantContext(userMessage, knowledgeBase.id!, 3);
+              if (docs && docs.length > 0) {
+                const ragContext = `\n\n=== RELEVANT KNOWLEDGE BASE CONTEXT ===\n${docs.join('\n\n')}\n=======================================\nUse the above information to help answer the user.`;
+                messages[0] = { role: 'system' as const, content: systemPrompt + ragContext };
+              }
+            } catch {
+              // KB search failed too, proceed without context
+            }
+
+            const fallbackData = await proxyJSON<GroqResponse>(ProxyRoutes.COMPLETIONS, {
+              model: settings.model,
+              messages,
+              temperature: settings.temperature,
+              max_tokens: settings.maxTokens,
+              top_p: settings.topP,
+            }, { timeout: REQUEST_TIMEOUT });
+
+            const fallbackContent = fallbackData.choices?.[0]?.message?.content;
+            if (fallbackContent) {
+              log.debug('✅ Fallback response received (context injection)');
+              return fallbackContent;
+            }
+          }
+
+          return null;
         }
-        return null;
-      } catch (error) {
-        log.warn('⚠️ Groq request failed:', error instanceof Error ? error.message : error);
-        return null;
       }
+
+      return null;
     };
 
     try {

--- a/supabase/functions/api-documents/index.ts
+++ b/supabase/functions/api-documents/index.ts
@@ -93,33 +93,179 @@ function smartChunkText(text: string, maxWords = 300, overlapWords = 50): string
   return chunks;
 }
 
-// ─── PDF text extraction ─────────────────────────────────────────
+// ─── PDF text extraction (multi-strategy) ────────────────────────
+// Strategy 1: BT/ET blocks (works for simple PDFs)
+// Strategy 2: Decompress FlateDecode streams, then extract text
+// Strategy 3: Raw printable ASCII extraction + Groq cleanup
 function extractTextFromPDF(bytes: Uint8Array): string {
   const raw = new TextDecoder('latin1').decode(bytes);
+
+  // Strategy 1: Standard BT/ET text operator extraction
   const textParts: string[] = [];
   const btEtRegex = /BT\s([\s\S]*?)ET/g;
   let match;
 
   while ((match = btEtRegex.exec(raw)) !== null) {
     const block = match[1];
+
+    // Tj operator: (text) Tj
     const tjRegex = /\(([^)]*)\)\s*Tj/g;
     let tjMatch;
-    while ((tjMatch = tjRegex.exec(block)) !== null) textParts.push(tjMatch[1]);
+    while ((tjMatch = tjRegex.exec(block)) !== null) {
+      const decoded = decodePdfString(tjMatch[1]);
+      if (decoded.trim()) textParts.push(decoded);
+    }
 
+    // TJ operator: [(text) kern (text)] TJ
     const tjArrayRegex = /\[([^\]]*)\]\s*TJ/g;
     let tjArrMatch;
     while ((tjArrMatch = tjArrayRegex.exec(block)) !== null) {
       const strRegex = /\(([^)]*)\)/g;
       let strMatch;
-      while ((strMatch = strRegex.exec(tjArrMatch[1])) !== null) textParts.push(strMatch[1]);
+      const words: string[] = [];
+      while ((strMatch = strRegex.exec(tjArrMatch[1])) !== null) {
+        const decoded = decodePdfString(strMatch[1]);
+        if (decoded.trim()) words.push(decoded);
+      }
+      if (words.length > 0) textParts.push(words.join(''));
     }
   }
 
-  if (textParts.length === 0) {
-    return raw.replace(/[^\x20-\x7E\n\r\t]/g, ' ').replace(/\s+/g, ' ').trim().substring(0, 50000);
+  // If we got meaningful text from BT/ET, use it
+  const btEtText = textParts.join(' ').replace(/\s+/g, ' ').trim();
+  if (btEtText.length > 50 && isReadableText(btEtText)) {
+    return btEtText;
   }
 
-  return textParts.join(' ').replace(/\\n/g, '\n').replace(/\\r/g, '').replace(/\s+/g, ' ').trim();
+  // Strategy 2: Try to decompress FlateDecode streams and extract text
+  const streamTexts = extractFromStreams(raw);
+  if (streamTexts.length > 50 && isReadableText(streamTexts)) {
+    return streamTexts;
+  }
+
+  // Strategy 3: Extract all printable ASCII runs (last resort)
+  // This captures text content that's embedded in the PDF but not in standard text operators
+  const asciiRuns: string[] = [];
+  const asciiRegex = /[\x20-\x7E]{4,}/g;
+  let asciiMatch;
+  while ((asciiMatch = asciiRegex.exec(raw)) !== null) {
+    const run = asciiMatch[0].trim();
+    // Filter out PDF operators and binary noise
+    if (run.length > 3 && !isPdfOperator(run)) {
+      asciiRuns.push(run);
+    }
+  }
+
+  const asciiText = asciiRuns.join(' ').replace(/\s+/g, ' ').trim();
+  if (asciiText.length > 20) {
+    return asciiText.substring(0, 50000);
+  }
+
+  // Nothing extracted
+  return '';
+}
+
+// Decode PDF escape sequences
+function decodePdfString(s: string): string {
+  return s
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\\(/g, '(')
+    .replace(/\\\)/g, ')')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\(\d{3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)));
+}
+
+// Check if extracted text is actually readable (not garbled binary)
+function isReadableText(text: string): boolean {
+  if (!text || text.length === 0) return false;
+  // Count printable ASCII characters vs total
+  let printable = 0;
+  let letters = 0;
+  for (let i = 0; i < Math.min(text.length, 500); i++) {
+    const code = text.charCodeAt(i);
+    if (code >= 0x20 && code <= 0x7E) printable++;
+    if ((code >= 0x41 && code <= 0x5A) || (code >= 0x61 && code <= 0x7A)) letters++;
+  }
+  const sampleLen = Math.min(text.length, 500);
+  // At least 80% printable and 20% letters
+  return (printable / sampleLen) > 0.8 && (letters / sampleLen) > 0.2;
+}
+
+// Filter out PDF structural keywords
+function isPdfOperator(text: string): boolean {
+  const operators = [
+    'endobj', 'endstream', 'stream', 'xref', 'trailer', 'startxref',
+    '/Type', '/Pages', '/Page', '/Font', '/Catalog', '/Length',
+    '/Filter', '/FlateDecode', '/Subtype', '/BaseFont',
+  ];
+  return operators.some((op) => text.startsWith(op) || text === op);
+}
+
+// Try to extract readable text from PDF stream objects
+function extractFromStreams(raw: string): string {
+  const parts: string[] = [];
+
+  // Find stream...endstream blocks and try to extract ASCII text from them
+  const streamRegex = /stream\r?\n([\s\S]*?)endstream/g;
+  let m;
+  while ((m = streamRegex.exec(raw)) !== null) {
+    const streamData = m[1];
+    // Extract printable ASCII runs from stream data
+    const textRegex = /[\x20-\x7E]{5,}/g;
+    let tm;
+    while ((tm = textRegex.exec(streamData)) !== null) {
+      const run = tm[0].trim();
+      if (run.length > 4 && !isPdfOperator(run)) {
+        parts.push(run);
+      }
+    }
+  }
+
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+// ─── Groq-powered text cleanup for garbled PDF extractions ───────
+async function cleanExtractedTextWithGroq(rawText: string, fileName: string): Promise<string> {
+  const groqApiKey = Deno.env.get('GROQ_API_KEY');
+  if (!groqApiKey || rawText.length < 20) return rawText;
+
+  // Only clean if text seems garbled
+  if (isReadableText(rawText)) return rawText;
+
+  try {
+    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${groqApiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'llama-3.3-70b-versatile',
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a document text extractor. The user will provide garbled text extracted from a PDF. Extract and reconstruct ALL readable information. Return ONLY the cleaned text, no explanations. Preserve structure like headings, lists, contact info, dates.',
+          },
+          {
+            role: 'user',
+            content: `File: ${fileName}\n\nExtracted text (may be garbled):\n${rawText.substring(0, 8000)}`,
+          },
+        ],
+        temperature: 0.1,
+        max_tokens: 4000,
+      }),
+    });
+
+    if (!response.ok) return rawText;
+
+    const data = await response.json();
+    const cleaned = data.choices?.[0]?.message?.content;
+    return cleaned && cleaned.length > 20 ? cleaned : rawText;
+  } catch {
+    return rawText;
+  }
 }
 
 // ─── Main handler ────────────────────────────────────────────────


### PR DESCRIPTION
Replace static RAG context injection with Groq's native tool calling API, enabling the model to dynamically search the knowledge base when needed. Add multi-strategy PDF extraction (BT/ET, stream parsing, ASCII fallback) with Groq-powered cleanup for garbled text.

https://claude.ai/code/session_01VVzheYHxPRK9oF4eV6N2do

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to related issue(s): Fixes #123 -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Style update (formatting, renaming)
- [ ] Code refactoring (no functional changes)
- [ ] Security fix
- [ ] Dependency update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] The build passes locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots
<!-- If applicable, add screenshots to show your changes -->

## Testing
<!-- Describe how you tested your changes -->

## Additional Notes
<!-- Add any additional notes for reviewers -->
