### PR TITLE
fix: handle agent-initiated disconnect and guard handleEndCall

### DIFF
--- a/src/components/DemoCall/UserPhoneInterface.tsx
+++ b/src/components/DemoCall/UserPhoneInterface.tsx
@@ -40,16 +40,41 @@ export default function UserPhoneInterface({
 
     const timerRef = useRef<NodeJS.Timeout | null>(null);
 
+    // Tracks when the WebSocket connected so we can log the live-to-dead delta.
+    const connectTimeRef = useRef<number | null>(null);
+
+    // Inline type that matches @elevenlabs/types DisconnectionDetails union.
+    // Defined here so diagnostics compile even before node_modules is installed.
+    type DisconnectionDetails =
+        | { reason: 'error'; message: string; context?: Event; closeCode?: number; closeReason?: string }
+        | { reason: 'agent'; context?: CloseEvent; closeCode?: number; closeReason?: string }
+        | { reason: 'user' };
+
     // Memoized callbacks — stable references prevent useConversation from
     // re-initialising on every render, which can reset the active WebSocket.
     const onConnect = useCallback(() => {
-        console.log('📞 ElevenLabs Conversational AI connected');
+        connectTimeRef.current = Date.now();
+        console.log('📞 [DIAG] ElevenLabs connected at', new Date().toISOString());
         setConnectionError(null);
         setAgentStatus('listening');
     }, []);
 
-    const onDisconnect = useCallback(() => {
-        console.log('📞 ElevenLabs Conversational AI disconnected');
+    const onDisconnect = useCallback((details?: DisconnectionDetails) => {
+        const uptime = connectTimeRef.current !== null
+            ? Date.now() - connectTimeRef.current
+            : null;
+        connectTimeRef.current = null;
+
+        // ─── DIAGNOSTIC: log every field so we can identify the root cause ───
+        console.log('📞 [DIAG] ElevenLabs disconnected', {
+            reason:      details?.reason ?? '(none)',
+            message:     (details as { message?: string })?.message,
+            closeCode:   (details as { closeCode?: number })?.closeCode,
+            closeReason: (details as { closeReason?: string })?.closeReason,
+            uptimeMs:    uptime,
+            timestamp:   new Date().toISOString(),
+        });
+
         setAgentStatus('idle');
     }, []);
 
@@ -67,13 +92,19 @@ export default function UserPhoneInterface({
         }
     }, [addMessage, onTranscript]);
 
-    const onError = useCallback((error: string) => {
-        console.error('📞 ElevenLabs error:', error);
-        setConnectionError(typeof error === 'string' ? error : 'Connection error');
+    const onError = useCallback((message: string, context?: unknown) => {
+        // ─── DIAGNOSTIC: log message AND the context object (closeCode, etc.) ───
+        console.error('📞 [DIAG] ElevenLabs error:', message, context);
+        try {
+            console.error('📞 [DIAG] ElevenLabs error context (JSON):', JSON.stringify(context, null, 2));
+        } catch {
+            // context may not be serialisable (e.g. native Event)
+        }
+        setConnectionError(message ?? 'Connection error');
     }, []);
 
     const onModeChange = useCallback((modeEvent: { mode: string }) => {
-        console.log('📞 Mode:', modeEvent.mode);
+        console.log('📞 [DIAG] Mode change →', modeEvent.mode, 'at', new Date().toISOString());
         if (modeEvent.mode === 'speaking') {
             setAgentStatus('speaking');
             setCurrentTranscript('');

--- a/src/components/DemoCall/UserPhoneInterface.tsx
+++ b/src/components/DemoCall/UserPhoneInterface.tsx
@@ -76,7 +76,13 @@ export default function UserPhoneInterface({
         });
 
         setAgentStatus('idle');
-    }, []);
+
+        // If the agent or an error closed the socket (not the user pressing End Call),
+        // clean up the call session so the UI returns to the idle/start state.
+        if (details?.reason !== 'user') {
+            endCall();
+        }
+    }, [endCall]);
 
     const onMessage = useCallback((message: { source: string; message: string }) => {
         console.log(`📞 [${message.source}]: ${message.message}`);
@@ -198,8 +204,13 @@ export default function UserPhoneInterface({
         console.log('🔴 End call button pressed');
         setIsEnding(true);
 
-        // End ElevenLabs session
-        await conversation.endSession();
+        // Only close the socket if it's still open — the agent may have already
+        // closed it (e.g. it said "thank you for calling" and hung up), in which
+        // case calling endSession() again throws "WebSocket is already in CLOSING
+        // or CLOSED state".
+        if (conversation.status !== 'disconnected') {
+            await conversation.endSession();
+        }
 
         setAgentStatus('idle');
         await endCall();

--- a/src/components/DemoCall/UserPhoneInterface.tsx
+++ b/src/components/DemoCall/UserPhoneInterface.tsx
@@ -214,10 +214,14 @@ export default function UserPhoneInterface({
     const conversationRef = useRef(conversation);
     conversationRef.current = conversation;
 
-    // Cleanup on unmount — end any active ElevenLabs session
+    // Cleanup on unmount — end any active ElevenLabs session.
+    // Guard with status check to avoid "WebSocket is already in CLOSING or CLOSED state"
+    // when handleEndCall already closed the socket before the component unmounts.
     useEffect(() => {
         return () => {
-            conversationRef.current.endSession();
+            if (conversationRef.current.status !== 'disconnected') {
+                conversationRef.current.endSession();
+            }
         };
     }, []);
 


### PR DESCRIPTION
## What was happening

The agent says "thank you for calling" then hangs up (`reason: "agent"`). At that point the WebSocket is already `CLOSED`. Two things went wrong:

1. **WebSocket error on End Call button**: User sees the idle UI but `currentCall` was still active, so clicking End Call called `conversation.endSession()` on a dead socket → `"WebSocket is already in CLOSING or CLOSED state"`.

2. **UI stuck in active-call state**: `onDisconnect` only called `setAgentStatus('idle')` but never called `endCall()`, so `currentCall.status` stayed `'active'` and the full-screen call UI never dismissed.

## Fixes

**Guard `handleEndCall`** — skip `endSession()` if the socket is already gone:
```ts
if (conversation.status !== 'disconnected') {
    await conversation.endSession();
}
```

**Auto-cleanup in `onDisconnect`** — when the agent (or an error) closes the call, call `endCall()` so the UI resets:
```ts
if (details?.reason !== 'user') {
    endCall();
}
```

## Note on the "thank you for calling" behaviour

The agent ending the call immediately is an **ElevenLabs agent configuration issue** — the agent likely has an `end_call` tool that's triggering too early, or its system prompt / first message is a farewell. This code change makes the frontend handle it gracefully, but the agent config should also be reviewed in the ElevenLabs dashboard.

https://claude.ai/code/session_01SGdxNUC1TVMDtW73TZbxjW